### PR TITLE
Implements event-driven streaming async

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
 Suggests:
     base64enc,
     bslib,
+    curl (>= 6.0.1),
     gitcreds,
     knitr,
     later (>= 1.3.2.9001),
@@ -37,6 +38,7 @@ Suggests:
 VignetteBuilder:
     knitr
 Remotes:
+    jeroen/curl,
     r-lib/later,
     jcheng5/shinychat
 Config/Needs/website: tidyverse/tidytemplate, rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,6 @@ Suggests:
 VignetteBuilder:
     knitr
 Remotes:
-    jeroen/curl,
     r-lib/later,
     jcheng5/shinychat
 Config/Needs/website: tidyverse/tidytemplate, rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Suggests:
     bslib,
     gitcreds,
     knitr,
-    later,
+    later (>= 1.3.2.9001),
     magick,
     openssl,
     paws.common,
@@ -37,6 +37,7 @@ Suggests:
 VignetteBuilder:
     knitr
 Remotes:
+    r-lib/later,
     jcheng5/shinychat
 Config/Needs/website: tidyverse/tidytemplate, rmarkdown
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # elmer (development version)
 
+* Async and streaming async chat are now event-driven and use `later::later_fd()` to wait efficiently on curl socket activity (#157).
+
 * New `chat_bedrock()` to chat with AWS bedrock models (#50).
 
 * New `chat$extract_data()` uses the structured data API where available (and tool calling otherwise) to extract data structured according to a known type specification. You can create specs with functions `type_boolean()`, `type_integer()`, `type_number()`, `type_string()`, `type_enum()`, `type_array()`, and `type_object()` (#31).

--- a/R/httr2.R
+++ b/R/httr2.R
@@ -52,14 +52,17 @@ chat_perform_async_value <- function(provider, req) {
   promises::then(req_perform_promise(req), resp_body_json)
 }
 
-on_load(chat_perform_async_stream <- coro::async_generator(function(provider, req, polling_interval_secs = 0.1) {
+on_load(chat_perform_async_stream <- coro::async_generator(function(provider, req) {
   resp <- req_perform_connection(req, blocking = FALSE)
   on.exit(close(resp))
 
   repeat {
     event <- chat_resp_stream(provider, resp)
     if (is.null(event) && isIncomplete(resp$body)) {
-      await(coro::async_sleep(polling_interval_secs))
+      fds <- curl::multi_fdset(resp$body)
+      await(promises::promise(function(resolve, reject) {
+        later::later_fd(resolve, fds$reads, fds$writes, fds$exceptions, fds$timeout)
+      }))
       next
     }
 


### PR DESCRIPTION
Minimal changes required here at `elmer` to enable streaming async.

Already reviewed by @jcheng5.

Also depends on an update to `curl` to allow us to use `curl::multi_fdset()` on the curl connection at `resp$body`, which Jeroen has already kindly merged.

Closes #157.