### PR TITLE
Add support for Databricks U2M and M2M OAuth credentials

### DIFF
--- a/man/chat_databricks.Rd
+++ b/man/chat_databricks.Rd
@@ -9,7 +9,7 @@ chat_databricks(
   system_prompt = NULL,
   turns = NULL,
   model = NULL,
-  token = databricks_token(workspace),
+  token = NULL,
   api_args = list(),
   echo = c("none", "text", "all")
 )
@@ -36,7 +36,8 @@ models include:
 \item \verb{databricks-meta-llama-3-1-405b-instruct}
 }}
 
-\item{token}{An authentication token for the Databricks workspace.}
+\item{token}{An authentication token for the Databricks workspace, or
+\code{NULL} to use ambient credentials.}
 
 \item{api_args}{Named list of arbitrary extra arguments appended to the body
 of every chat API call.}
@@ -61,6 +62,17 @@ and can also serve as a gateway for external models hosted by a third party.
 Databricks models do not support images, but they do support structured
 outputs. Tool calling support is also very limited at present; too limited
 for \code{elmer}'s tool calling features to work properly at all.
+
+\code{chat_databricks()} picks up on ambient Databricks credentials for a subset
+of the \href{https://docs.databricks.com/en/dev-tools/auth/unified-auth.html}{Databricks client unified authentication}
+model. Specifically, it supports:
+\itemize{
+\item Personal access tokens
+\item Service principals via OAuth (OAuth M2M)
+\item User account via OAuth (OAuth U2M)
+\item Authentication via the Databricks CLI
+\item Posit Workbench-managed credentials
+}
 }
 \seealso{
 Other chatbots: 

--- a/tests/testthat/_snaps/provider-databricks.md
+++ b/tests/testthat/_snaps/provider-databricks.md
@@ -5,3 +5,30 @@
     Message
       Using model = "databricks-dbrx-instruct".
 
+# M2M authentication requests look correct
+
+    Code
+      list(url = req$url, headers = req$headers, body = req$body$data)
+    Output
+      $url
+      [1] "https://example.cloud.databricks.com/oidc/v1/token"
+      
+      $headers
+      $headers$Authorization
+      [1] "Basic aWQ6c2VjcmV0"
+      
+      $headers$Accept
+      [1] "application/json"
+      
+      attr(,"redact")
+      [1] "Authorization"
+      
+      $body
+      $body$grant_type
+      [1] "client_credentials"
+      
+      $body$scope
+      [1] "all-apis"
+      
+      
+

--- a/tests/testthat/test-provider-databricks.R
+++ b/tests/testthat/test-provider-databricks.R
@@ -53,3 +53,30 @@ test_that("can use images", {
   # test_images_inline(chat_databricks)
   # test_images_remote(chat_databricks)
 })
+
+# Auth --------------------------------------------------------------------
+
+test_that("Databricks PATs are detected correctly", {
+  withr::local_envvar(
+    DATABRICKS_HOST = "https://example.cloud.databricks.com",
+    DATABRICKS_TOKEN = "token"
+  )
+  expect_equal(databricks_token(), "token")
+  expect_equal(databricks_token(token = "another token"), "another token")
+})
+
+test_that("M2M authentication requests look correct", {
+  withr::local_envvar(
+    DATABRICKS_HOST = "https://example.cloud.databricks.com",
+    DATABRICKS_CLIENT_ID = "id",
+    DATABRICKS_CLIENT_SECRET = "secret"
+  )
+  local_mocked_responses(function(req) {
+    # Snapshot relevant fields of the outgoing request.
+    expect_snapshot(
+      list(url = req$url, headers = req$headers, body = req$body$data)
+    )
+    response_json(body = list(access_token = "token"))
+  })
+  expect_equal(databricks_token(), "token")
+})


### PR DESCRIPTION
Use of Databricks personal access tokens are generally discouraged nowadays, the preferred authentication method for Databricks is now OAuth -- either "user to machine", which uses the authorization code flow, or "machine to machine", which is a client credentials flow.

This commit adds support for both. In the process it also adds support for caching and refreshing these credentials correctly across multiple turns.

Unit tests are included for M2M and PAT credentials; U2M credentials are difficult to mock because they require an authorization code flow.

This change also unlocks our ability to use a Databricks service principal to run `elmer`'s own integration tests.