### PR TITLE
Fix `chat_databricks()` failures due to S7 validation

### DIFF
--- a/R/provider-databricks.R
+++ b/R/provider-databricks.R
@@ -54,7 +54,10 @@ chat_databricks <- function(workspace = databricks_workspace(),
     base_url = workspace,
     model = model,
     extra_args = api_args,
-    token = token
+    token = token,
+    # Databricks APIs use bearer tokens, not API keys, but we need to pass an
+    # empty string here anyway to make S7::validate() happy.
+    api_key = ""
   )
   Chat$new(provider = provider, turns = turns, echo = echo)
 }

--- a/tests/testthat/test-provider-databricks.R
+++ b/tests/testthat/test-provider-databricks.R
@@ -20,6 +20,9 @@ test_that("can make simple streaming request", {
 # Common provider interface -----------------------------------------------
 
 test_that("defaults are reported", {
+  # Setting a dummy host ensures we don't skip this test, even if there are no
+  # Databricks credentials available.
+  withr::local_envvar(DATABRICKS_HOST = "https://example.cloud.databricks.com")
   expect_snapshot(. <- chat_databricks())
 })
 


### PR DESCRIPTION
Previously calling `chat_databricks()` would yield:

    Error:
    ! <elmer::ProviderOpenAI> object properties are invalid:
    - @api_key must be a single string, not an empty character vector. Hide Traceback ▆
     1. └─elmer::chat_databricks(...)
     2.   └─elmer:::ProviderDatabricks(...) at elmer/R/provider-databricks.R:58:3
     3.     ├─S7::new_object(...)
     4.     └─elmer:::ProviderOpenAI(...)
     5.       └─S7::new_object(...)
     6.         └─S7::validate(object, recursive = !parent_validated)

This is because the default value for `api_key` is `character(0)`, not `""`. I didn't catch this until I updated my local development packages and started seeing the error.

This commit fixes this by passing `api_key` explicitly. It also ensures that at least one Databricks unit test will run even when no credentials are available, which would have caught this earlier.