### PR TITLE
Bump promises required version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Imports:
     httr2 (>= 1.0.6.9000),
     jsonlite,
     later (>= 1.3.2.9001),
+    promises (>= 1.3.0.9001),
     R6,
     rlang (>= 1.1.0),
     S7 (>= 0.2.0)
@@ -29,7 +30,6 @@ Suggests:
     magick,
     openssl,
     paws.common,
-    promises,
     rmarkdown,
     shiny,
     shinychat (>= 0.0.0.9000),
@@ -40,6 +40,7 @@ VignetteBuilder:
 Remotes:
     r-lib/later,
     r-lib/httr2,
+    rstudio/promises,
     jcheng5/shinychat
 Config/Needs/website: tidyverse/tidytemplate, rmarkdown
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
     httr2 (>= 1.0.6.9000),
     jsonlite,
     later (>= 1.3.2.9001),
-    promises (>= 1.3.0.9001),
+    promises (>= 1.3.1),
     R6,
     rlang (>= 1.1.0),
     S7 (>= 0.2.0)
@@ -40,7 +40,6 @@ VignetteBuilder:
 Remotes:
     r-lib/later,
     r-lib/httr2,
-    rstudio/promises,
     jcheng5/shinychat
 Config/Needs/website: tidyverse/tidytemplate, rmarkdown
 Config/testthat/edition: 3


### PR DESCRIPTION
Fixes a bug where promise domain is forgotten during tool calling

Hope to submit this version of {promises} to CRAN today

Update: now on CRAN