### PR TITLE
Bump later required version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Imports:
     glue,
     httr2 (>= 1.0.6.9000),
     jsonlite,
-    later (>= 1.3.2.9001),
+    later (>= 1.4.0),
     R6,
     rlang (>= 1.1.0),
     S7 (>= 0.2.0)
@@ -38,7 +38,6 @@ Suggests:
 VignetteBuilder:
     knitr
 Remotes:
-    r-lib/later,
     r-lib/httr2,
     jcheng5/shinychat
 Config/Needs/website: tidyverse/tidytemplate, rmarkdown


### PR DESCRIPTION
later 1.4.0 is now on CRAN. Thanks!