### PR TITLE
Adds support for non localhost ollama models. Fixes #197

### DIFF
--- a/R/provider-ollama.R
+++ b/R/provider-ollama.R
@@ -40,7 +40,7 @@ chat_ollama <- function(system_prompt = NULL,
   chat_openai(
     system_prompt = system_prompt,
     turns = turns,
-    base_url = file.path(base_url, "v1"),
+    base_url = file.path(base_url, "v1"), ## the v1 portion of the path is added for openAI compatible API
     api_key = "ollama", # ignored
     model = model,
     seed = seed,
@@ -50,7 +50,8 @@ chat_ollama <- function(system_prompt = NULL,
 }
 
 ollama_models <- function(base_url = "http://localhost:11434") {
-  req <- request(file.path(base_url, "api/tags"))
+  req <- request(base_url)
+  req <- req_url_path(req, "api/tags")
   resp <- req_perform(req)
   json <- resp_body_json(resp)
 
@@ -61,7 +62,9 @@ ollama_models <- function(base_url = "http://localhost:11434") {
 has_ollama <- function(base_url = "http://localhost:11434") {
   tryCatch(
     {
-      req_perform(request(file.path(base_url, "api/tags")))
+      req <- request(base_url)
+      req <- req_url_path(req, "api/tags")
+      req_perform(req)
       TRUE
     },
     httr2_error = function(cnd) FALSE

--- a/R/provider-ollama.R
+++ b/R/provider-ollama.R
@@ -19,18 +19,18 @@
 #' @family chatbots
 #' @export
 chat_ollama <- function(system_prompt = NULL,
-                            turns = NULL,
-                            base_url = "http://localhost:11434/v1",
-                            model,
-                            seed = NULL,
-                            api_args = list(),
-                            echo = NULL) {
-  if (!has_ollama()) {
+                        turns = NULL,
+                        base_url = "http://localhost:11434",
+                        model,
+                        seed = NULL,
+                        api_args = list(),
+                        echo = NULL) {
+  if (!has_ollama(base_url)) {
     cli::cli_abort("Can't find locally running ollama.")
   }
 
   if (missing(model)) {
-    models <- ollama_models()
+    models <- ollama_models(base_url)
     cli::cli_abort(c(
       "Must specify {.arg model}.",
       i = "Locally installed models: {.str {models}}."
@@ -40,7 +40,7 @@ chat_ollama <- function(system_prompt = NULL,
   chat_openai(
     system_prompt = system_prompt,
     turns = turns,
-    base_url = base_url,
+    base_url = file.path(base_url, "v1"),
     api_key = "ollama", # ignored
     model = model,
     seed = seed,
@@ -49,8 +49,8 @@ chat_ollama <- function(system_prompt = NULL,
   )
 }
 
-ollama_models <- function() {
-  req <- request("http://localhost:11434/api/tags")
+ollama_models <- function(base_url = "http://localhost:11434") {
+  req <- request(file.path(base_url, "api/tags"))
   resp <- req_perform(req)
   json <- resp_body_json(resp)
 
@@ -58,10 +58,10 @@ ollama_models <- function() {
   gsub(":latest$", "", names)
 }
 
-has_ollama <- function() {
+has_ollama <- function(base_url = "http://localhost:11434") {
   tryCatch(
     {
-      req_perform(request("http://localhost:11434/api/tags"))
+      req_perform(request(file.path(base_url, "api/tags")))
       TRUE
     },
     httr2_error = function(cnd) FALSE

--- a/man/chat_ollama.Rd
+++ b/man/chat_ollama.Rd
@@ -7,7 +7,7 @@
 chat_ollama(
   system_prompt = NULL,
   turns = NULL,
-  base_url = "http://localhost:11434/v1",
+  base_url = "http://localhost:11434",
   model,
   seed = NULL,
   api_args = list(),


### PR DESCRIPTION
I tried to write up the description in issue #197. In short, this makes it possible to use ollama models hosted on a remote machine.