### PR TITLE
Modify serialization strategy for tool results

### DIFF
--- a/R/chat.R
+++ b/R/chat.R
@@ -251,6 +251,12 @@ Chat <- R6::R6Class("Chat",
     #' @description Register a tool (an R function) that the chatbot can use.
     #'   If the chatbot decides to use the function,  elmer will automatically
     #'   call it and submit the results back.
+    #' 
+    #'   The return value of the function. Generally, this should either be a
+    #'   string, or a JSON-serializable value. If you must have more direct
+    #'   control of the structure of the JSON that's returned, you can return a
+    #'   JSON-serializable value wrapped in [base::I()], which elmer will leave
+    #'   alone until the entire request is JSON-serialized.
     #' @param tool_def Tool definition created by [tool()].
     register_tool = function(tool_def) {
       if (!S7_inherits(tool_def, ToolDef)) {

--- a/R/content.R
+++ b/R/content.R
@@ -217,8 +217,12 @@ tool_string <- function(x) {
     paste0("Tool calling failed with error ", x@error)
   } else if (inherits(x@value, "AsIs")) {
     x@value
+  } else if (inherits(x@value, "json")) {
+    x@value
+  } else if (is.character(x@value)) {
+    paste(x@value, collapse = "\n")
   } else {
-    toString(x@value)
+    jsonlite::toJSON(x@value, auto_unbox = TRUE)
   }
 }
 

--- a/R/content.R
+++ b/R/content.R
@@ -215,6 +215,8 @@ tool_errored <- function(x) !is.null(x@error)
 tool_string <- function(x) {
   if (tool_errored(x)) {
     paste0("Tool calling failed with error ", x@error)
+  } else if (inherits(x@value, "AsIs")) {
+    x@value
   } else {
     toString(x@value)
   }


### PR DESCRIPTION
Closes #230 

### Update 2024-12-18 14:25 PST

This went from a very targeted "Add `I()` to a tool result to prevent it from being double JSON encoded" to changing the default serialization strategy for tool call responses.

The previous behavior only really made sense if you returned a single-element character vector or the output of `jsonlite::toJSON()`; these work the same way in the new code. But the new code also makes sense for multi-element character vectors (collapses them with `"\n"`) and for JSON-serializable objects (they are automatically serialized), in addition to `I()`.